### PR TITLE
Fix implicit deletion bug

### DIFF
--- a/backend/pkg/database/dbtestutils/tests.go
+++ b/backend/pkg/database/dbtestutils/tests.go
@@ -42,7 +42,7 @@ func ProductsTest(t *testing.T, openDB func() database.DB) {
 
 	require.NoError(t, db.SetProduct(product1), "Could not override Product")
 	p, ok = db.LookupProduct(product1.Name)
-	require.True(t, ok, "Could not find Product just overridden created")
+	require.True(t, ok, "Could not find Product just overridden")
 	require.Equal(t, product1, p, "Product does not match the one just overridden")
 
 	require.NoError(t, db.SetProduct(product2), "Could not set Product")
@@ -114,7 +114,14 @@ func RecipesTest(t *testing.T, openDB func() database.DB) {
 
 	require.NoError(t, db.SetRecipe(recipe1), "Could not override Recipe")
 	p, ok = db.LookupRecipe(recipe1.Name)
-	require.True(t, ok, "Could not find Recipe just overridden created")
+	require.True(t, ok, "Could not find Recipe just overridden")
+	require.Equal(t, recipe1, p, "Recipe does not match the one just overridden")
+
+	// Test implicit deletion of ingredients
+	recipe1.Ingredients = recipe1.Ingredients[:1]
+	require.NoError(t, db.SetRecipe(recipe1), "Could not override Recipe")
+	p, ok = db.LookupRecipe(recipe1.Name)
+	require.True(t, ok, "Could not find Recipe just overridden")
 	require.Equal(t, recipe1, p, "Recipe does not match the one just overridden")
 
 	require.NoError(t, db.SetRecipe(recipe2), "Could not set Recipe")
@@ -192,7 +199,15 @@ func MenuTest(t *testing.T, openDB func() database.DB) {
 
 	require.NoError(t, db.SetMenu(myMenu), "Could not override Menu")
 	m, ok = db.LookupMenu(myMenu.Name)
-	require.True(t, ok, "Could not find Menu just overridden created")
+	require.True(t, ok, "Could not find Menu just overridden")
+	require.Equal(t, myMenu, m, "Menu does not match the one just overridden")
+
+	// Test implicit deletion of dishes
+	myMenu.Days[0].Meals[0].Dishes = nil
+
+	require.NoError(t, db.SetMenu(myMenu), "Could not override Menu")
+	m, ok = db.LookupMenu(myMenu.Name)
+	require.True(t, ok, "Could not find Menu just overridden")
 	require.Equal(t, myMenu, m, "Menu does not match the one just overridden")
 
 	emptyMenu := types.Menu{
@@ -268,7 +283,14 @@ func PantriesTest(t *testing.T, openDB func() database.DB) {
 
 	require.NoError(t, db.SetPantry(pantry1), "Could not override Pantry")
 	p, ok = db.LookupPantry(pantry1.Name)
-	require.True(t, ok, "Could not find Pantry just overridden created")
+	require.True(t, ok, "Could not find Pantry just overridden")
+	require.Equal(t, pantry1, p, "Pantry does not match the one just overridden")
+
+	// Test implicit deletion of ingredients
+	pantry1.Contents = pantry1.Contents[:1]
+	require.NoError(t, db.SetPantry(pantry1), "Could not override Pantry")
+	p, ok = db.LookupPantry(pantry1.Name)
+	require.True(t, ok, "Could not find Pantry just overridden")
 	require.Equal(t, pantry1, p, "Pantry does not match the one just overridden")
 
 	require.NoError(t, db.SetPantry(pantry2), "Could not set Pantry")
@@ -341,7 +363,14 @@ func ShoppingListsTest(t *testing.T, openDB func() database.DB) {
 
 	require.NoError(t, db.SetShoppingList(list1), "Could not override ShoppingList")
 	p, ok = db.LookupShoppingList(list1.Name)
-	require.True(t, ok, "Could not find ShoppingList just overridden created")
+	require.True(t, ok, "Could not find ShoppingList just overridden")
+	require.Equal(t, list1, p, "ShoppingList does not match the one just overridden")
+
+	// Test implicit deletion of items
+	list1.Items = list1.Items[:1]
+	require.NoError(t, db.SetShoppingList(list1), "Could not override ShoppingList")
+	p, ok = db.LookupShoppingList(list1.Name)
+	require.True(t, ok, "Could not find ShoppingList just overridden")
 	require.Equal(t, list1, p, "ShoppingList does not match the one just overridden")
 
 	require.NoError(t, db.SetShoppingList(list2), "Could not set ShoppingList")

--- a/backend/pkg/database/mysql/menus.go
+++ b/backend/pkg/database/mysql/menus.go
@@ -460,46 +460,25 @@ func (s *SQL) setMenu(tx *sql.Tx, name string) error {
 }
 
 func (s *SQL) setDays(tx *sql.Tx, rows []dayMenuRow) error {
-	for _, row := range rows {
-		_, err := tx.ExecContext(s.ctx, `
-			INSERT INTO menu_days (menu_name, pos, name)
-			VALUES (?, ?, ?)`,
-			row.Menu, row.Pos, row.Name,
-		)
-		if err != nil {
-			return fmt.Errorf("could not insert menu day: %v", err)
-		}
-	}
-
-	return nil
+	return bulkInsert(s, tx,
+		"menu_days (menu_name, pos, name)", rows,
+		func(row dayMenuRow) []any {
+			return []any{row.Menu, row.Pos, row.Name}
+		})
 }
 
 func (s *SQL) setMeals(tx *sql.Tx, rows []mealMenuRow) error {
-	for _, row := range rows {
-		_, err := tx.ExecContext(s.ctx, `
-			INSERT INTO menu_day_meals (menu_name, day_pos, pos, name)
-			VALUES (?, ?, ?, ?)`,
-			row.Menu, row.DayPos, row.Pos, row.Name,
-		)
-		if err != nil {
-			return fmt.Errorf("could not insert menu meal: %v", err)
-		}
-	}
-
-	return nil
+	return bulkInsert(s, tx,
+		"menu_day_meals (menu_name, day_pos, pos, name)", rows,
+		func(row mealMenuRow) []any {
+			return []any{row.Menu, row.DayPos, row.Pos, row.Name}
+		})
 }
 
 func (s *SQL) setItems(tx *sql.Tx, rows []mealItemRow) error {
-	for _, row := range rows {
-		_, err := tx.ExecContext(s.ctx, `
-			INSERT INTO menu_day_meal_recipes (menu_name, day_pos, meal_pos, pos, recipe_name, amount)
-			VALUES (?, ?, ?, ?, ?, ?)`,
-			row.Menu, row.DayPos, row.MealPos, row.Pos, row.Recipe, row.Amount,
-		)
-		if err != nil {
-			return fmt.Errorf("could not insert meal item: %v", err)
-		}
-	}
-
-	return nil
+	return bulkInsert(s, tx,
+		"menu_day_meal_recipes (menu_name, day_pos, meal_pos, pos, recipe_name, amount)", rows,
+		func(row mealItemRow) []any {
+			return []any{row.Menu, row.DayPos, row.MealPos, row.Pos, row.Recipe, row.Amount}
+		})
 }

--- a/backend/pkg/database/mysql/pantries.go
+++ b/backend/pkg/database/mysql/pantries.go
@@ -157,6 +157,11 @@ func (s *SQL) SetPantry(p types.Pantry) error {
 		return fmt.Errorf("could not insert pantry: %v", err)
 	}
 
+	// Remove all items from the pantry
+	_, err = tx.ExecContext(s.ctx, "DELETE FROM pantry_items WHERE pantry_name = ?", p.Name)
+	if err != nil {
+		return fmt.Errorf("could not delete old pantry items: %v", err)
+	}
 
 	err = bulkInsert(s, tx,
 		"pantry_items (pantry_name, product_name, amount)",

--- a/backend/pkg/database/mysql/pantries.go
+++ b/backend/pkg/database/mysql/pantries.go
@@ -157,11 +157,15 @@ func (s *SQL) SetPantry(p types.Pantry) error {
 		return fmt.Errorf("could not insert pantry: %v", err)
 	}
 
-	for _, item := range p.Contents {
-		_, err = tx.ExecContext(s.ctx, "REPLACE INTO pantry_items (pantry_name, product_name, amount) VALUES (?, ?, ?)", p.Name, item.Name, item.Amount)
-		if err != nil {
-			return fmt.Errorf("could not insert pantry item: %v", err)
-		}
+
+	err = bulkInsert(s, tx,
+		"pantry_items (pantry_name, product_name, amount)",
+		p.Contents,
+		func(i types.Ingredient) []any {
+			return []any{p.Name, i.Name, i.Amount}
+		})
+	if err != nil {
+		return fmt.Errorf("could not insert new pantry items: %v", err)
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/backend/pkg/database/mysql/recipes.go
+++ b/backend/pkg/database/mysql/recipes.go
@@ -3,7 +3,6 @@ package mysql
 import (
 	"database/sql"
 	"fmt"
-	"strings"
 
 	"github.com/EduardGomezEscandell/grocery-price-fetcher/backend/pkg/types"
 )
@@ -186,29 +185,14 @@ func (s *SQL) SetRecipe(r types.Recipe) error {
 		return fmt.Errorf("could not insert recipe: %v", err)
 	}
 
-	if len(r.Ingredients) > 1000 {
-		// This is an arbitrary limit to prevent abuse
-		return fmt.Errorf("too many ingredients")
-	}
 
-	if len(r.Ingredients) != 0 {
-		//nolint:gosec // The query is constructed by the code, not user input
-		queryIngredients := `
-		REPLACE INTO
-		recipe_ingredients (recipe_name, ingredient_name, amount)
-		VALUES
-		` + repeatString("(?, ?, ?)", ", ", len(r.Ingredients))
-
-		s.log.Tracef(queryIngredients)
-
-		var argv []any
-		for _, i := range r.Ingredients {
-			argv = append(argv, r.Name, i.Name, i.Amount)
-		}
-
-		if _, err := tx.ExecContext(s.ctx, queryIngredients, argv...); err != nil {
-			return fmt.Errorf("could not insert ingredients: %v", err)
-		}
+	err = bulkInsert(s, tx,
+		"recipe_ingredients(recipe_name, ingredient_name, amount)",
+		r.Ingredients, func(i types.Ingredient) []interface{} {
+			return []interface{}{r.Name, i.Name, i.Amount}
+		})
+	if err != nil {
+		return fmt.Errorf("could not insert ingredients: %v", err)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -262,23 +246,4 @@ func (s *SQL) deleteRecipeIngredients(tx *sql.Tx, name string) error {
 	}
 
 	return nil
-}
-
-func repeatString(str string, sep string, n int) string {
-	switch n {
-	case 0:
-		return ""
-	case 1:
-		return str
-	}
-
-	var b strings.Builder
-	b.Grow(len(str)*n + len(sep)*(n-1))
-	b.WriteString(str)
-	for range n - 1 {
-		b.WriteString(sep)
-		b.WriteString(str)
-	}
-
-	return b.String()
 }

--- a/backend/pkg/database/mysql/recipes.go
+++ b/backend/pkg/database/mysql/recipes.go
@@ -185,6 +185,9 @@ func (s *SQL) SetRecipe(r types.Recipe) error {
 		return fmt.Errorf("could not insert recipe: %v", err)
 	}
 
+	if err := s.deleteRecipeIngredients(tx, r.Name); err != nil {
+		return fmt.Errorf("could not delete old ingredients: %v", err)
+	}
 
 	err = bulkInsert(s, tx,
 		"recipe_ingredients(recipe_name, ingredient_name, amount)",

--- a/backend/pkg/database/mysql/shoppinglists.go
+++ b/backend/pkg/database/mysql/shoppinglists.go
@@ -175,14 +175,12 @@ func (s *SQL) SetShoppingList(list types.ShoppingList) error {
 		return fmt.Errorf("could not insert shopping list: %v", err)
 	}
 
-	for _, item := range list.Items {
-		query := `REPLACE INTO shopping_list_items (shopping_list_name, product_name) VALUES (?, ?)`
-		s.log.Trace(query)
 
-		_, err = tx.ExecContext(s.ctx, query, list.Name, item)
-		if err != nil {
-			return fmt.Errorf("could not insert shopping list item: %v", err)
-		}
+	err = bulkInsert(s, tx, "shopping_list_items(shopping_list_name, product_name)", list.Items, func(s string) []any {
+		return []any{list.Name, s}
+	})
+	if err != nil {
+		return fmt.Errorf("could not insert shopping list items: %v", err)
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/backend/pkg/database/mysql/shoppinglists.go
+++ b/backend/pkg/database/mysql/shoppinglists.go
@@ -175,6 +175,10 @@ func (s *SQL) SetShoppingList(list types.ShoppingList) error {
 		return fmt.Errorf("could not insert shopping list: %v", err)
 	}
 
+	_, err = tx.ExecContext(s.ctx, "DELETE FROM shopping_list_items WHERE shopping_list_name = ?", list.Name)
+	if err != nil {
+		return fmt.Errorf("could not delete old shopping list items: %v", err)
+	}
 
 	err = bulkInsert(s, tx, "shopping_list_items(shopping_list_name, product_name)", list.Items, func(s string) []any {
 		return []any{list.Name, s}


### PR DESCRIPTION
Remove bulk data before re-adding it

This is relevant because inserting a list may have an implicit deletion:

BEFORE:
   house, tree, road
AFTER
   house, office, tree

This change implicitly deletes the 'road' and adds an 'office'. I could
calculate the delta to hit the DB as little as possible but I'm too
lazy for that, so instead I DELETE the old list and INSERT the new one.