### PR TITLE
Wrong URLs should respond 404, not 406

### DIFF
--- a/backend/pkg/services/frontend/frontend.go
+++ b/backend/pkg/services/frontend/frontend.go
@@ -46,16 +46,16 @@ func (s Service) HandleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := httputils.ValidateAccepts(r, httputils.MediaTypeHTML); err != nil {
-		msg := err.(httputils.RequestError).Err.Error() //nolint:forcetypeassert,errorlint // we know it's a RequestError
-		http.Error(w, msg, http.StatusNotAcceptable)
-		return
-	}
-
 	if p, ok := s.resolvePath(w, r.URL.Path); !ok {
 		return
 	} else {
 		r.URL.Path = p
+	}
+
+	if err := httputils.ValidateAccepts(r, httputils.MediaTypeHTML); err != nil {
+		msg := err.(httputils.RequestError).Err.Error() //nolint:forcetypeassert,errorlint // we know it's a RequestError
+		http.Error(w, msg, http.StatusNotAcceptable)
+		return
 	}
 
 	http.FileServer(s.fs).ServeHTTP(w, r)


### PR DESCRIPTION
We must validate the URL before the headers in the front-end service, because it is also the base URL that catches all wrong URLs.